### PR TITLE
1 file notebooks: h5coro and h5py (Rachel)

### DIFF
--- a/contributors/rachel/h5coro.ipynb
+++ b/contributors/rachel/h5coro.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {
+    "user_expressions": []
+   },
+   "source": [
+    "# Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## setup\n",
+    "\n",
+    "Must install h5coro to have it accessible as an engine.\n",
+    "\n",
+    "Must use pip **not** conda. conda h5coro is v0.0.6, which does not have the funcionality to be located by xarray as a backend. pip h5coro is v0.0.8, which does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "641cc544-c028-4feb-9747-0528fc0b9fb3",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install h5coro -qq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import earthaccess\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5611747f-4141-44c6-9031-26cbf83b5ded",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['netcdf4', 'h5netcdf', 'scipy', 'h5coro', 'kerchunk', 'rasterio', 'store', 'zarr'])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Confirm h5coro backend loaded properly\n",
+    "# should see 'h5coro' in the list\n",
+    "xr.backends.list_engines().keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0d56482-1eb7-443f-ad41-01f1669451a5",
+   "metadata": {},
+   "source": [
+    "## Authenticating"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "46b0c4cd-f585-42b1-bccf-c3e8509641e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3url_atl06 = 'nsidc-cumulus-prod-protected/ATLAS/ATL06/006/2019/12/02/ATL06_20191202203649_10220511_006_01.h5'\n",
+    "auth = earthaccess.login()\n",
+    "creds = auth.get_s3_credentials(daac='NSIDC')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20011e72-bae8-4150-a873-6e400a109298",
+   "metadata": {},
+   "source": [
+    "## Data Access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c3bebe3c-5712-484e-8267-d093c6d69f7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.43 s ± 353 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 5\n",
+    "\n",
+    "ds = xr.open_dataset(s3url_atl06, engine='h5coro', group='/gt2l/land_ice_segments', credentials=creds)\n",
+    "ds.h_li.load()\n",
+    "ds.latitude.load()\n",
+    "ds.longitude.load()\n",
+    "ds.delta_time.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5055909-df26-4e93-9400-9e13d32566ba",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16a7040e-8589-4382-854c-9bc5701a95c8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5b5946-362b-42a0-bdde-fc9b36c635c4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ee92c49-4895-4e6a-b4cc-546abeb24c53",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/contributors/rachel/h5py_test.ipynb
+++ b/contributors/rachel/h5py_test.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f9036cea-37c5-408e-8eb3-42b42333350b",
+   "metadata": {},
+   "source": [
+    "# h5py (direct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d97bc28a-c891-4682-a56c-977dcb73bb1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import fsspec\n",
+    "import earthaccess"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "195a82bf-5bda-4bd3-bb12-954f8216ec2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = earthaccess.get_s3fs_session(daac=\"NSIDC\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "783f0d08-9b90-4a9f-9f43-896aa25878d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 's3://nsidc-cumulus-prod-protected/ATLAS/ATL06/006/2019/12/02/ATL06_20191202203649_10220511_006_01.h5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e60b1d81-d2de-4483-81e0-a8b7b1c03174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fsspec_kwargs = {\n",
+    "    \"cache_type\": \"blockcache\", \n",
+    "    \"block_size\": 8*1024*1024\n",
+    "}\n",
+    "\n",
+    "h5py_kwargs = {\n",
+    "    # \"page_buf_size\": 16*1024*1024,\n",
+    "    \"rdcc_nbytes\": 4*1024*1024\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "56afe4a6-6a30-47ac-ac2c-77f6e338e296",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "777 ms ± 22 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 5\n",
+    "\n",
+    "with s3.open(url, 'rb', **fsspec_kwargs) as fo:\n",
+    "    with h5py.File(fo, **h5py_kwargs) as f:\n",
+    "        data0 = f['gt2l']['land_ice_segments']['h_li'][:]\n",
+    "        data1 = f['gt2l']['land_ice_segments']['latitude'][:]\n",
+    "        data2 = f['gt2l']['land_ice_segments']['longitude'][:]\n",
+    "        data3 = f['gt2l']['land_ice_segments']['delta_time'][:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e4bf7a51-6612-48e5-9588-e62ab0fc55db",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.159772"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(data0.nbytes + data1.nbytes + data2.nbytes + data3.nbytes) / 1e6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02e20447-736a-4bf0-ad2f-f64780a3cc02",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8310d76-40fc-46db-ad4b-c65a02eb3d7b",
+   "metadata": {},
+   "source": [
+    "### xarray + h5py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "64e993fd-c32d-431b-804f-65e47178f098",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "383c5ae7-c2fd-4820-8a7b-8027c9663539",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.02 s ± 10.7 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 5\n",
+    "\n",
+    "with s3.open(url, 'rb', **fsspec_kwargs) as fo:\n",
+    "    ds = xr.open_dataset(\n",
+    "        fo, engine='h5netcdf', group='/gt2l/land_ice_segments', driver_kwds={\"rdcc_nbytes\": 1024*1024}\n",
+    "    )\n",
+    "    ds.h_li.load()\n",
+    "    ds.latitude.load()\n",
+    "    ds.longitude.load()\n",
+    "    ds.delta_time.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e32d4cb2-d992-464a-8c44-72336cb1a27e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dac6b56f-d52f-4a50-a4ce-4826491bed86",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.078205"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.nbytes / 1e6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff8b8703-367c-49bc-be18-3466885432c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/contributors/rachel/xarray_fsspec_h5py.ipynb
+++ b/contributors/rachel/xarray_fsspec_h5py.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f7eda91d-adf4-4e2b-8e2c-f836d9a0bb88",
+   "metadata": {},
+   "source": [
+    "### xarray + h5py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "95504ee2-95ed-42d4-a19e-29b46f536afa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "226d8ab9-9117-4e88-8fc0-ae9795ea6df5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.02 s ± 10.7 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -r 5\n",
+    "\n",
+    "with s3.open(url, 'rb', **fsspec_kwargs) as fo:\n",
+    "    ds = xr.open_dataset(\n",
+    "        fo, engine='h5netcdf', group='/gt2l/land_ice_segments', driver_kwds={\"rdcc_nbytes\": 1024*1024}\n",
+    "    )\n",
+    "    ds.h_li.load()\n",
+    "    ds.latitude.load()\n",
+    "    ds.longitude.load()\n",
+    "    ds.delta_time.load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e91558d8-f35d-4170-9bbe-22c02667606a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ed3ef45f-a3bf-47a3-80ae-413bfe0d00e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.078205"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.nbytes / 1e6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee5359d-8585-4830-a0c6-6c675a4a13f6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add notebooks for reading the `gt2l` beam out of 1 file:
- `h5coro`
- `h5py` (direct)
- `xarray` + `fsspec` + `h5py`
